### PR TITLE
README: correct installation instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ mkdir -p ~/ros2_ws/src && cd ~/ros2_ws/src
 
 ```bash
 cd ~/ros2_ws/src
-wget https://raw.githubusercontent.com/srmainwaring/ardupilot_gz/ros2_gz.repos
+wget https://raw.githubusercontent.com/srmainwaring/ardupilot_gz/main/ros2_gz.repos
 vcs import --recursive < ros2_gz.repos
 ```
 


### PR DESCRIPTION
Correct path to ros2_gz.repos file.