### PR TITLE
Copter: add battery and sensors to iris

### DIFF
--- a/ardupilot_gz_bringup/config/iris_bridge.yaml
+++ b/ardupilot_gz_bringup/config/iris_bridge.yaml
@@ -34,3 +34,40 @@
   ros_type_name: "sensor_msgs/msg/CameraInfo"
   gz_type_name: "gz.msgs.CameraInfo"
   direction: GZ_TO_ROS
+
+- ros_topic_name: "/air_pressure"
+  gz_topic_name: "/world/map/model/iris/link/base_link/sensor/air_pressure_sensor/air_pressure"
+  ros_type_name: "sensor_msgs/msg/FluidPressure"
+  gz_type_name: "gz.msgs.FluidPressure"
+  direction: GZ_TO_ROS
+
+# - ros_topic_name: "/air_speed"
+#   gz_topic_name: "/world/map/model/iris/link/base_link/sensor/air_speed_sensor/air_speed"
+#   ros_type_name: "geometry_msgs/msg/Vector3Stamped"
+#   gz_type_name: "gz.msgs.AirSpeedSensor"
+#   direction: GZ_TO_ROS
+
+# - ros_topic_name: "/altimeter"
+#   gz_topic_name: "/world/map/model/iris/link/base_link/sensor/altimeter_sensor/altimeter"
+#   ros_type_name: "geometry_msgs/msg/Vector3Stamped"
+#   gz_type_name: "gz.msgs.Altimeter"
+#   direction: GZ_TO_ROS
+
+- ros_topic_name: "/imu"
+  gz_topic_name: "/world/map/model/iris/link/imu_link/sensor/imu_sensor/imu"
+  ros_type_name: "sensor_msgs/msg/Imu"
+  gz_type_name: "gz.msgs.IMU"
+  direction: GZ_TO_ROS
+
+- ros_topic_name: "/magnetometer"
+  gz_topic_name: "/world/map/model/iris/link/base_link/sensor/magnetometer_sensor/magnetometer"
+  ros_type_name: "sensor_msgs/msg/MagneticField"
+  gz_type_name: "gz.msgs.Magnetometer"
+  direction: GZ_TO_ROS
+
+- ros_topic_name: "/navsat"
+  gz_topic_name: "/world/map/model/iris/link/base_link/sensor/navsat_sensor/navsat"
+  ros_type_name: "sensor_msgs/msg/NavSatFix"
+  gz_type_name: "gz.msgs.NavSat"
+  direction: GZ_TO_ROS
+

--- a/ardupilot_gz_bringup/config/iris_bridge.yaml
+++ b/ardupilot_gz_bringup/config/iris_bridge.yaml
@@ -71,3 +71,8 @@
   gz_type_name: "gz.msgs.NavSat"
   direction: GZ_TO_ROS
 
+- ros_topic_name: "/battery"
+  gz_topic_name: "/model/iris/battery/linear_battery/state"
+  ros_type_name: "sensor_msgs/msg/BatteryState"
+  gz_type_name: "gz.msgs.BatteryState"
+  direction: GZ_TO_ROS

--- a/ardupilot_gz_gazebo/worlds/iris_runway.sdf
+++ b/ardupilot_gz_gazebo/worlds/iris_runway.sdf
@@ -20,8 +20,23 @@
     <plugin filename="gz-sim-scene-broadcaster-system"
       name="gz::sim::systems::SceneBroadcaster">
     </plugin>
+    <plugin filename="gz-sim-air-pressure-system"
+      name="gz::sim::systems::AirPressure">
+    </plugin>
+    <plugin filename="gz-sim-air-speed-system"
+      name="gz::sim::systems::AirSpeed">
+    </plugin>
+    <plugin filename="gz-sim-altimeter-system"
+      name="gz::sim::systems::Altimeter">
+    </plugin>
     <plugin filename="gz-sim-imu-system"
       name="gz::sim::systems::Imu">
+    </plugin>
+    <plugin filename="gz-sim-magnetometer-system"
+      name="gz::sim::systems::Magnetometer">
+    </plugin>
+    <plugin filename="gz-sim-navsat-system"
+      name="gz::sim::systems::NavSat">
     </plugin>
 
     <scene>
@@ -43,6 +58,14 @@
       </attenuation>
       <direction>-0.5 0.1 -0.9</direction>
     </light>
+
+    <spherical_coordinates>
+      <latitude_deg>-35.3632621</latitude_deg>
+      <longitude_deg>149.1652374</longitude_deg>
+      <elevation>10.0</elevation>
+      <heading_deg>0</heading_deg>
+      <surface_model>EARTH_WGS84</surface_model>
+    </spherical_coordinates>
 
     <include>
       <uri>model://runway</uri>


### PR DESCRIPTION
Add simple battery model and additional sensors to the Iris.

## Details

- Add battery plugin.
- Add air_pressure
- Add magnetometer
- Add navsat

## Tests

Example showing battery message mapped from Gazebo through to ROS 2.

```bash
$ ros2 topic echo /battery
---
header:
  stamp:
    sec: 222
    nanosec: 324000000
  frame_id: ''
voltage: 12.061639785766602
temperature: 0.0
current: 16.57807731628418
charge: 4.003036975860596
capacity: 5.0
design_capacity: .nan
percentage: 80.06074523925781
power_supply_status: 2
power_supply_health: 0
power_supply_technology: 0
present: true
cell_voltage: []
cell_temperature: []
location: ''
serial_number: ''
---
```